### PR TITLE
add Atomist webhook to Travis

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -1,0 +1,16 @@
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.0-20170809213747"
+editor:
+  name: "AddTravisWebhookEditor"
+  group: "spildrazil"
+  artifact: "spring-team-handlers"
+  version: "0.8.129"
+  origin:
+    repo: "git@github.com:atomisthq/spring-team-handlers"
+    branch: "master"
+    sha: "b70d3b6*"
+  parameters:
+    - "atomistWebhookUrl": "https://webhook-staging.atomist.services/atomist/travis"
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.atomist.yml linguist-generated=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,11 @@
 install:
   - i am the build definition
+notifications:
+  webhooks:
+    urls:
+    - 'https://webhook-staging.atomist.services/atomist/travis'
+    on_cancel: always
+    on_error: always
+    on_start: always
+    on_failure: always
+    on_success: always


### PR DESCRIPTION
Created by Atomist Editor `AddTravisWebhookEditor`
```
---
kind: "operation"
client: "com.atomist:rug"
version: "1.0.0-20170809213747"
editor:
  name: "AddTravisWebhookEditor"
  group: "spildrazil"
  artifact: "spring-team-handlers"
  version: "0.8.129"
  origin:
    repo: "git@github.com:atomisthq/spring-team-handlers"
    branch: "master"
    sha: "b70d3b6*"
  parameters:
    - "atomistWebhookUrl": "https://webhook-staging.atomist.services/atomist/travis"

```